### PR TITLE
I've refactored `ConversationHistory` to use `ChatMessage` internally.

### DIFF
--- a/src/main/ai_base.py
+++ b/src/main/ai_base.py
@@ -1,5 +1,6 @@
 """This module defines the abstract base class for AI engines."""
 import abc
+from src.main.types import ConversationHistory
 
 class AIEngine(abc.ABC):
     """Abstract base class for AI engines.
@@ -18,13 +19,14 @@ class AIEngine(abc.ABC):
         self.model_name = model_name
 
     @abc.abstractmethod
-    def generate_response(self, role_name: str, system_prompt: str, conversation_history: list[dict]) -> str:
+    def generate_response(self, role_name: str, system_prompt: str, conversation_history: ConversationHistory) -> str:
         """Generates a response from the AI engine.
 
         Args:
             role_name: The name of the role for the AI.
             system_prompt: The system prompt to use.
-            conversation_history: The conversation history.
+            conversation_history: A ConversationHistory object representing the
+                                  current conversation.
 
         Returns:
             The response from the AI engine.

--- a/src/main/ai_bots.py
+++ b/src/main/ai_bots.py
@@ -3,6 +3,7 @@ import logging # For logging
 from .ai_base import AIEngine # Import AIEngine from its new location
 from .ai_engines import GeminiEngine, GrokEngine, OpenAIEngine # Import necessary engine classes
 from . import ai_engines # Import the ai_engines package to access ENGINE_TYPE_TO_CLASS_MAP
+from .types import ConversationHistory # Import ConversationHistory
 # Removed os, requests, google.generativeai, openai imports as they are now in respective engine files.
 
 # Bot class and create_bot function remain here.
@@ -89,11 +90,12 @@ class Bot:
         """
         self.engine = new_engine
 
-    def generate_response(self, conversation_history: list[dict]) -> str:
+    def generate_response(self, conversation_history: ConversationHistory) -> str:
         """Generates a response from the bot's AI engine.
 
         Args:
-            conversation_history: The conversation history.
+            conversation_history: A ConversationHistory object representing the
+                                  current conversation.
 
         Returns:
             The response from the AI engine.
@@ -106,7 +108,7 @@ class Bot:
             response = self.engine.generate_response(
                 role_name=self.name,
                 system_prompt=self.system_prompt,
-                conversation_history=conversation_history
+                conversation_history=conversation_history.to_list_dict() # Pass the list[dict] representation
             )
             self.logger.info(f"Bot '{self.name}' successfully generated response.") # INFO
             return response

--- a/src/main/ai_engines/azure_openai_engine.py
+++ b/src/main/ai_engines/azure_openai_engine.py
@@ -13,6 +13,7 @@ import os
 import openai
 from ..ai_base import AIEngine
 from .. import commons
+from ..types import ConversationHistory
 
 
 class AzureOpenAIEngine(AIEngine):
@@ -62,7 +63,7 @@ class AzureOpenAIEngine(AIEngine):
         )
         logging.info(f"AzureOpenAIEngine initialized with deployment: {self.deployment_name}, endpoint: {self.azure_endpoint}")
 
-    def generate_response(self, role_name: str, system_prompt: str, conversation_history: list[dict]) -> str:
+    def generate_response(self, role_name: str, system_prompt: str, conversation_history: ConversationHistory) -> str:
         """Generates a response using the configured Azure OpenAI model.
 
         Constructs a message list suitable for the Azure OpenAI API from the
@@ -74,15 +75,17 @@ class AzureOpenAIEngine(AIEngine):
             role_name (str): The name of the assistant role in the conversation.
                              Messages from this role are mapped to "assistant".
             system_prompt (str): The system prompt to guide the AI's behavior.
-            conversation_history (list[dict]): A list of message dictionaries,
-                                               where each dictionary has 'role' and 'text'.
+            conversation_history (ConversationHistory): A ConversationHistory object
+                                                        containing the current
+                                                        conversation.
 
         Returns:
             str: The generated text response from the AI, or an error message
                  if generation fails.
         """
         messages = [{"role": "system", "content": system_prompt}]
-        for msg in conversation_history:
+        history_list_dict = conversation_history.to_list_dict()
+        for msg in history_list_dict:
             if msg['role'] == role_name:
                 messages.append({"role": "assistant", "content": msg['text']})
             else:

--- a/src/main/ai_engines/grok_engine.py
+++ b/src/main/ai_engines/grok_engine.py
@@ -8,6 +8,7 @@ response generation is attempted.
 import logging
 import requests # For Grok, if/when a real API call is made
 from ..ai_base import AIEngine # Use relative import from new location
+from ..types import ConversationHistory # Import ConversationHistory
 
 
 class GrokEngine(AIEngine):
@@ -44,7 +45,7 @@ class GrokEngine(AIEngine):
             self.logger.info("GrokEngine: API key was provided, but it will not be actively used due to the lack of an official API/SDK.")
 
 
-    def generate_response(self, role_name: str, system_prompt: str, conversation_history: list[dict]) -> str:
+    def generate_response(self, role_name: str, system_prompt: str, conversation_history: ConversationHistory) -> str:
         """Attempts to generate a response using Grok (currently a placeholder).
 
         Since there is no official public API for Grok, this method returns
@@ -53,13 +54,16 @@ class GrokEngine(AIEngine):
         Args:
             role_name (str): The name of the assistant role in the conversation.
             system_prompt (str): The system prompt to guide the AI's behavior.
-            conversation_history (list[dict]): A list of message dictionaries.
+            conversation_history (ConversationHistory): A ConversationHistory object
+                                                        containing the current
+                                                        conversation.
 
         Returns:
             str: An error message stating that the Grok API is not implemented.
         """
         # Adjusted parameters to match the base class abstract method
-        self.logger.info(f"Generating placeholder response for GrokEngine. System_prompt_len={len(system_prompt)}, history_len={len(conversation_history)} for role {role_name}.")
+        history_list_dict = conversation_history.to_list_dict()
+        self.logger.info(f"Generating placeholder response for GrokEngine. System_prompt_len={len(system_prompt)}, history_len={len(history_list_dict)} for role {role_name}.")
         # Research indicates no publicly available official Python SDK or well-documented public REST API for Grok by xAI.
         # Some third-party libraries exist but rely on unofficial methods (e.g., reverse-engineering X app's API).
         # Using such methods is brittle and potentially against terms of service.

--- a/src/main/types.py
+++ b/src/main/types.py
@@ -1,0 +1,215 @@
+"""
+Defines custom types for the application, primarily focusing on conversation management.
+"""
+
+from typing import List, Dict, Optional
+
+class ChatMessage:
+    """
+    Represents a single message in a conversation.
+
+    Attributes:
+        role (str): The role of the entity that produced the message (e.g., "User", "Bot", "System").
+        text (str): The textual content of the message.
+    """
+    def __init__(self, role: str, text: str):
+        """
+        Initializes a ChatMessage instance.
+
+        Args:
+            role: The role of the speaker (e.g., "User", "Bot").
+            text: The content of the message.
+        """
+        self.role = role
+        self.text = text
+
+    def to_dict(self) -> Dict[str, str]:
+        """
+        Converts the ChatMessage instance to a dictionary.
+
+        Returns:
+            A dictionary representation of the message with "role" and "text" keys.
+        """
+        return {"role": self.role, "text": self.text}
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, str]) -> 'ChatMessage':
+        """
+        Creates a new ChatMessage instance from a dictionary.
+
+        Args:
+            data: A dictionary with "role" and "text" keys.
+
+        Returns:
+            A new ChatMessage instance.
+        
+        Raises:
+            KeyError: If "role" or "text" is missing from the input dictionary.
+        """
+        if "role" not in data or "text" not in data:
+            raise KeyError("Input dictionary must contain 'role' and 'text' keys.")
+        return cls(role=data["role"], text=data["text"])
+
+    def __str__(self) -> str:
+        """
+        Returns a user-friendly string representation of the message.
+
+        Formats the message as "Role: Text". The role is capitalized.
+
+        Returns:
+            A string representation of the message.
+        """
+        return f"{self.role.capitalize()}: {self.text}"
+
+    def __repr__(self) -> str:
+        """
+        Returns an unambiguous string representation of the ChatMessage object.
+
+        Returns:
+            A string that can ideally be used to recreate the object.
+        """
+        return f"ChatMessage(role='{self.role}', text={repr(self.text)})"
+
+
+class ConversationHistory:
+    """
+    Manages a history of conversation messages.
+
+    Internally, it stores messages as ChatMessage objects.
+    Provides methods to add messages, convert to/from list of dictionaries
+    (for external compatibility), and generate a user-friendly string representation.
+    """
+
+    def __init__(self, initial_history: Optional[List[Dict[str, str]]] = None):
+        """
+        Initializes the ConversationHistory.
+
+        Args:
+            initial_history: An optional list of message dictionaries to
+                             initialize the conversation history. Each dictionary
+                             should have "role" (str) and "text" (str) keys.
+                             These dictionaries are converted to ChatMessage objects internally.
+        """
+        self._history: List[ChatMessage] = []
+        if initial_history:
+            for item in initial_history:
+                try:
+                    self._history.append(ChatMessage.from_dict(item))
+                except KeyError as e:
+                    # Handle cases where a dictionary in initial_history might be malformed
+                    # For example, log a warning or skip the message
+                    print(f"Warning: Skipping message due to missing keys in initial_history: {item} - Error: {e}")
+
+
+    def add_message(self, role: str, text: str) -> None:
+        """
+        Adds a new message to the conversation history.
+
+        Args:
+            role: The role of the speaker (e.g., "User", "Bot").
+            text: The content of the message.
+        """
+        self._history.append(ChatMessage(role=role, text=text))
+
+    def to_list_dict(self) -> List[Dict[str, str]]:
+        """
+        Returns a list of message dictionaries from the internal ChatMessage objects.
+
+        This ensures that the internal history (of ChatMessage objects) is not
+        exposed directly and provides a serializable format.
+
+        Returns:
+            A new list of dictionaries, where each dictionary represents a message
+            with "role" and "text" keys.
+        """
+        return [message.to_dict() for message in self._history]
+
+    @classmethod
+    def from_list_dict(cls, data: List[Dict[str, str]]) -> 'ConversationHistory':
+        """
+        Creates a new ConversationHistory instance from a list of message dictionaries.
+
+        Args:
+            data: A list of dictionaries, where each dictionary represents a
+                  message with "role" and "text" keys.
+
+        Returns:
+            A new ConversationHistory instance populated with the provided data.
+        """
+        return cls(initial_history=data)
+
+    def __str__(self) -> str:
+        """
+        Returns a user-friendly string representation of the conversation history.
+
+        Each message is formatted as "Role: Text" on a new line, using the
+        __str__ method of ChatMessage.
+
+        Returns:
+            A string representing the conversation history.
+        """
+        if not self._history:
+            return "Conversation history is empty."
+        
+        # Each 'message' in self._history is now a ChatMessage object.
+        # We can directly use its __str__() representation or access attributes.
+        # Using message.__str__() directly leverages ChatMessage's formatting.
+        formatted_messages: List[str] = [str(message) for message in self._history]
+        return "\n".join(formatted_messages)
+
+if __name__ == '__main__':
+    # Example Usage (for testing purposes)
+    print("Starting example usage for custom types...")
+
+    # --- ChatMessage Example Usage ---
+    print("\n--- ChatMessage Examples ---")
+    msg1 = ChatMessage(role="User", text="Hello there!")
+    print(f"Message 1: {msg1}")
+    print(f"Message 1 (repr): {repr(msg1)}")
+    msg1_dict = msg1.to_dict()
+    print(f"Message 1 (dict): {msg1_dict}")
+
+    msg2_data = {"role": "Bot", "text": "Hi User!"}
+    msg2 = ChatMessage.from_dict(msg2_data)
+    print(f"Message 2 (from dict): {msg2}")
+    
+    try:
+        ChatMessage.from_dict({"role": "System"}) # Missing text
+    except KeyError as e:
+        print(f"Caught expected error for ChatMessage.from_dict: {e}")
+
+    # --- ConversationHistory Example Usage ---
+    print("\n--- ConversationHistory Examples ---")
+    # Test initialization
+    history1 = ConversationHistory()
+    print(f"Empty history: {history1}")
+
+    history1.add_message("User", "Hello")
+    history1.add_message("Bot", "Hi there!")
+    print(f"\nAfter adding messages:\n{history1}")
+
+    # Test to_list_dict
+    list_dict_representation = history1.to_list_dict()
+    print(f"\nList dict representation: {list_dict_representation}")
+
+    # Test from_list_dict
+    initial_data = [
+        {"role": "User", "text": "Good morning"},
+        {"role": "Bot", "text": "Good morning! How can I help you today?"}
+    ]
+    history2 = ConversationHistory.from_list_dict(initial_data)
+    print(f"\nHistory created from list_dict:\n{history2}")
+
+    history2.add_message("User", "I need help with my account.")
+    print(f"\nAfter adding another message to history2:\n{history2}")
+
+    # Test __str__ with an empty history again (new instance)
+    history3 = ConversationHistory()
+    print(f"\nString representation of a new empty history: {history3}")
+    
+    # Test __str__ with one message
+    history4 = ConversationHistory()
+    history4.add_message("System", "Session started.")
+    print(f"\nHistory with one message:\n{history4}")
+
+    print("\nExample usage finished.")

--- a/src/test/test_azure_openai_engine.py
+++ b/src/test/test_azure_openai_engine.py
@@ -6,6 +6,7 @@ from unittest.mock import patch, MagicMock
 # from src.main.ai_engines.azure_openai_engine import AzureOpenAIEngine
 from src.main.ai_engines.azure_openai_engine import AzureOpenAIEngine
 from src.main.ai_base import AIEngine
+from src.main.types import ConversationHistory # Import ConversationHistory
 import openai # openai is still needed for the exception types
 import logging
 
@@ -104,7 +105,7 @@ class TestAzureOpenAIEngine(unittest.TestCase):
         response = self.engine.generate_response(
             role_name=self.role_name,
             system_prompt=self.system_prompt,
-            conversation_history=self.conversation_history_simple
+            conversation_history=ConversationHistory(self.conversation_history_simple)
         )
         
         self.assertEqual(response, "Test response")
@@ -121,7 +122,7 @@ class TestAzureOpenAIEngine(unittest.TestCase):
         response = self.engine.generate_response(
             role_name=self.role_name,
             system_prompt=self.system_prompt,
-            conversation_history=self.conversation_history_mixed # Using mixed for variety
+            conversation_history=ConversationHistory(self.conversation_history_mixed) # Using mixed for variety
         )
         
         self.assertEqual(response, "Error: No response generated.")
@@ -134,7 +135,7 @@ class TestAzureOpenAIEngine(unittest.TestCase):
         self.mock_openai_client.chat.completions.create.side_effect = openai.APIConnectionError(request=MagicMock())
         
         response = self.engine.generate_response(
-            self.role_name, self.system_prompt, self.conversation_history_simple
+            self.role_name, self.system_prompt, ConversationHistory(self.conversation_history_simple)
         )
         self.assertIn("Error: Could not connect to Azure OpenAI API.", response)
 
@@ -142,7 +143,7 @@ class TestAzureOpenAIEngine(unittest.TestCase):
         self.mock_openai_client.chat.completions.create.side_effect = openai.RateLimitError(message="Rate limit exceeded", response=MagicMock(), body=None)
         
         response = self.engine.generate_response(
-            self.role_name, self.system_prompt, self.conversation_history_simple
+            self.role_name, self.system_prompt, ConversationHistory(self.conversation_history_simple)
         )
         self.assertIn("Error: Azure OpenAI API rate limit exceeded.", response)
 
@@ -150,7 +151,7 @@ class TestAzureOpenAIEngine(unittest.TestCase):
         self.mock_openai_client.chat.completions.create.side_effect = openai.AuthenticationError(message="Authentication failed", response=MagicMock(), body=None)
         
         response = self.engine.generate_response(
-            self.role_name, self.system_prompt, self.conversation_history_simple
+            self.role_name, self.system_prompt, ConversationHistory(self.conversation_history_simple)
         )
         self.assertIn("Error: Azure OpenAI API authentication failed.", response)
 
@@ -159,7 +160,7 @@ class TestAzureOpenAIEngine(unittest.TestCase):
         self.mock_openai_client.chat.completions.create.side_effect = openai.APIError("Test API Error", request=MagicMock(), body={})
         
         response = self.engine.generate_response(
-            self.role_name, self.system_prompt, self.conversation_history_simple
+            self.role_name, self.system_prompt, ConversationHistory(self.conversation_history_simple)
         )
         self.assertIn("Error: An unexpected error occurred with the Azure OpenAI API.", response)
 
@@ -167,7 +168,7 @@ class TestAzureOpenAIEngine(unittest.TestCase):
         self.mock_openai_client.chat.completions.create.side_effect = Exception("Some unexpected error")
         
         response = self.engine.generate_response(
-            self.role_name, self.system_prompt, self.conversation_history_simple
+            self.role_name, self.system_prompt, ConversationHistory(self.conversation_history_simple)
         )
         self.assertIn("Error: An unexpected error occurred. Details: Some unexpected error", response)
 

--- a/src/test/test_types.py
+++ b/src/test/test_types.py
@@ -1,0 +1,159 @@
+import unittest
+from src.main.types import ConversationHistory, ChatMessage # Added ChatMessage
+
+class TestChatMessage(unittest.TestCase):
+    def test_initialization(self):
+        """Test ChatMessage initialization."""
+        msg = ChatMessage(role="User", text="Hello")
+        self.assertEqual(msg.role, "User")
+        self.assertEqual(msg.text, "Hello")
+
+    def test_to_dict(self):
+        """Test ChatMessage to_dict method."""
+        msg = ChatMessage(role="Bot", text="Hi there")
+        expected_dict = {"role": "Bot", "text": "Hi there"}
+        self.assertEqual(msg.to_dict(), expected_dict)
+
+    def test_from_dict_success(self):
+        """Test ChatMessage from_dict class method for successful creation."""
+        data = {"role": "System", "text": "System ready"}
+        msg = ChatMessage.from_dict(data)
+        self.assertIsInstance(msg, ChatMessage)
+        self.assertEqual(msg.role, "System")
+        self.assertEqual(msg.text, "System ready")
+
+    def test_from_dict_missing_keys(self):
+        """Test ChatMessage from_dict raises KeyError for missing keys."""
+        expected_error_msg = "Input dictionary must contain 'role' and 'text' keys."
+        with self.assertRaisesRegex(KeyError, expected_error_msg):
+            ChatMessage.from_dict({"role": "User"})  # Missing 'text'
+        
+        with self.assertRaisesRegex(KeyError, expected_error_msg):
+            ChatMessage.from_dict({"text": "Hello"})  # Missing 'role'
+
+        with self.assertRaisesRegex(KeyError, expected_error_msg):
+            ChatMessage.from_dict({}) # Missing both
+
+    def test_str_representation(self):
+        """Test ChatMessage __str__ method."""
+        msg = ChatMessage(role="User", text="Test message")
+        self.assertEqual(str(msg), "User: Test message")
+        
+        msg_lower_role = ChatMessage(role="bot", text="Another test")
+        self.assertEqual(str(msg_lower_role), "Bot: Another test") # Role should be capitalized
+
+    def test_repr_representation(self):
+        """Test ChatMessage __repr__ method."""
+        msg = ChatMessage(role="User", text="Hello")
+        expected_repr = "ChatMessage(role='User', text='Hello')" # repr of "Hello" is 'Hello'
+        self.assertEqual(repr(msg), expected_repr)
+
+        text_with_quotes = "Text with 'quotes'"
+        msg_with_quotes = ChatMessage(role="System", text=text_with_quotes)
+        # repr(text_with_quotes) will be "'Text with \\'quotes\\''"
+        # So the full repr should be ChatMessage(role='System', text='Text with \'quotes\'')
+        expected_repr_quotes = f"ChatMessage(role='System', text={repr(text_with_quotes)})"
+        self.assertEqual(repr(msg_with_quotes), expected_repr_quotes)
+
+
+class TestConversationHistory(unittest.TestCase):
+
+    def test_initialization_empty(self):
+        """Test empty initialization."""
+        ch = ConversationHistory()
+        self.assertEqual(ch.to_list_dict(), [])
+        self.assertEqual(str(ch), "Conversation history is empty.")
+
+    def test_initialization_with_history(self):
+        """Test initialization with a pre-existing history."""
+        initial_data = [
+            {"role": "User", "text": "Hello"},
+            {"role": "Bot", "text": "Hi there!"}
+        ]
+        ch = ConversationHistory(initial_data)
+        self.assertEqual(ch.to_list_dict(), initial_data)
+        # Ensure the internal list is a copy, not the same object
+        self.assertIsNot(ch.to_list_dict(), initial_data) 
+
+    def test_add_message(self):
+        """Test adding messages."""
+        ch = ConversationHistory()
+        ch.add_message("User", "First message")
+        expected_history1 = [{"role": "User", "text": "First message"}]
+        self.assertEqual(ch.to_list_dict(), expected_history1)
+
+        ch.add_message("Bot", "Second message")
+        expected_history2 = [
+            {"role": "User", "text": "First message"},
+            {"role": "Bot", "text": "Second message"}
+        ]
+        self.assertEqual(ch.to_list_dict(), expected_history2)
+
+    def test_to_list_dict_returns_copy(self):
+        """Test that to_list_dict returns a copy, not a reference."""
+        initial_data = [{"role": "User", "text": "Test"}]
+        ch = ConversationHistory(initial_data)
+        
+        list_dict_1 = ch.to_list_dict()
+        list_dict_2 = ch.to_list_dict()
+        
+        self.assertEqual(list_dict_1, list_dict_2)
+        self.assertIsNot(list_dict_1, list_dict_2, "to_list_dict should return a new list object each time.")
+        
+        # Also check modification of the returned list doesn't affect internal history
+        list_dict_1.append({"role": "Attempt", "text": "To Modify"})
+        self.assertEqual(ch.to_list_dict(), initial_data, "Modifying returned list should not affect internal history.")
+
+    def test_from_list_dict(self):
+        """Test creating an instance using from_list_dict."""
+        data = [
+            {"role": "System", "text": "System Ready"},
+            {"role": "User", "text": "User query"}
+        ]
+        ch = ConversationHistory.from_list_dict(data)
+        self.assertIsInstance(ch, ConversationHistory)
+        self.assertEqual(ch.to_list_dict(), data)
+        # Ensure the internal list is a copy
+        internal_list = ch.to_list_dict()
+        self.assertIsNot(internal_list, data)
+
+
+    def test_str_representation_empty(self):
+        """Test string representation for an empty history."""
+        ch = ConversationHistory()
+        self.assertEqual(str(ch), "Conversation history is empty.")
+
+    def test_str_representation_with_messages(self):
+        """Test string representation with messages."""
+        ch = ConversationHistory()
+        ch.add_message("User", "Hello Bot")
+        ch.add_message("Bot", "Hello User")
+        ch.add_message("user", "how are you?") # Test lowercase role
+        
+        expected_str = "User: Hello Bot\nBot: Hello User\nUser: how are you?"
+        self.assertEqual(str(ch), expected_str)
+
+    def test_str_representation_missing_keys(self):
+        """Test string representation when messages have missing keys."""
+        # This scenario should ideally not happen if add_message is used,
+        # but from_list_dict could allow it.
+        # Since ChatMessage.from_dict now strictly requires 'role' and 'text',
+        # ConversationHistory.__init__ will skip messages with missing keys from initial_history.
+        
+        data_with_missing_role = [{"text": "Just text"}] # 'role' is missing
+        ch_missing_role = ConversationHistory.from_list_dict(data_with_missing_role)
+        # Expect empty history because the malformed message is skipped.
+        self.assertEqual(str(ch_missing_role), "Conversation history is empty.")
+
+        data_with_missing_text = [{"role": "User"}] # 'text' is missing
+        ch_missing_text = ConversationHistory.from_list_dict(data_with_missing_text)
+        # Expect empty history because the malformed message is skipped.
+        self.assertEqual(str(ch_missing_text), "Conversation history is empty.")
+        
+        data_with_both_missing = [{}] # 'role' and 'text' are missing
+        ch_both_missing = ConversationHistory.from_list_dict(data_with_both_missing)
+        # Expect empty history because the malformed message is skipped.
+        self.assertEqual(str(ch_both_missing), "Conversation history is empty.")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Here's a summary of the changes to `ConversationHistory` in `src/main/types.py`:
- I introduced a new `ChatMessage` class to represent individual messages. This class has `role` and `text` attributes, and methods for converting to and from dictionaries (`to_dict`, `from_dict`) and for string representation.
- I modified `ConversationHistory` to store its history as a `List[ChatMessage]` instead of `List[Dict[str, str]]`.
- I updated the `ConversationHistory` methods (`__init__`, `add_message`, `to_list_dict`, `__str__`) to handle the conversion between the external `List[Dict[str, str]]` API and the internal `List[ChatMessage]` representation.

This change enhances type safety and encapsulation within `ConversationHistory`.

Additionally:
- I added comprehensive unit tests for the new `ChatMessage` class in `src/test/test_types.py`.
- I reviewed and updated existing unit tests for `ConversationHistory` to ensure compatibility with the internal changes.
- All unit tests pass.
- I updated the documentation for both classes in `src/main/types.py` to reflect these changes.